### PR TITLE
Refactor Afore integration for improved token management

### DIFF
--- a/afore.py
+++ b/afore.py
@@ -10,6 +10,10 @@ from importlib import metadata
 from typing import Any
 from .models import Status, System
 
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ACCESS_TOKEN
+
 import async_timeout
 from aiohttp.client import ClientError, ClientResponseError, ClientSession
 from aiohttp.hdrs import METH_GET, METH_POST
@@ -42,19 +46,27 @@ class AforeOutputAuthenticationError(Exception):
     pass
 
 
-@dataclass
 class Afore:
-    access_token: str | None
-
-    request_timeout: float = 30.0
-    session: ClientSession | None = None
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        request_timeout: float = 30.0,
+        session: ClientSession | None = None,
+    ) -> None:
+        """Initialize Afore."""
+        self._hass = hass
+        self._config_entry = config_entry
+        self.request_timeout = request_timeout
+        self.session = session
+        self._close_session = session is None
 
     async def _request(
         self,
         uri: str,
         *,
-        params: params,
-        jsonData: jsonData,
+        params: Any,
+        jsonData: Any,
         method: str = METH_POST,
         data: dict[str, Any] | None = None,
     ) -> str:
@@ -62,12 +74,12 @@ class Afore:
         if params is not None:
             url = url.with_query(params)
 
-        self.access_token = "" # TODO add getting the token from the addon config
+        access_token = self._config_entry.data.get(CONF_ACCESS_TOKEN)
 
         headers = {
             "Accept": "application/json, text/plain, */*",
             "User-Agent": f"Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/117.0",
-            "Authorization": "Bearer " + self.access_token,
+            "Authorization": "Bearer " + access_token,
             "Accept-Language": "en-US,en;q=0.7,pl;q=0.3",
             "Content-Type": "application/json;charset=UTF-8",
             "Accept-Encoding": "gzip, deflate",
@@ -120,8 +132,9 @@ class Afore:
             )
         )
         try:
+            access_token = self._config_entry.data.get(CONF_ACCESS_TOKEN)
             decoded_token = jwt.decode(
-                self.access_token, options={"verify_signature": False}
+                access_token, options={"verify_signature": False}
             )
             date = datetime.fromtimestamp(decoded_token["exp"])
             data["data"][0]["expirationDate"] = date
@@ -144,11 +157,12 @@ class Afore:
                 params="order.direction=DESC&order.property=id&page=1&size=20",
             )
         )
-        try:                                                                   
-            decoded_token = jwt.decode(                                        
-                self.access_token, options={"verify_signature": False}         
-            )                                                                  
-            date = datetime.fromtimestamp(decoded_token["exp"])                
+        try:
+            access_token = self._config_entry.data.get(CONF_ACCESS_TOKEN)
+            decoded_token = jwt.decode(
+                access_token, options={"verify_signature": False}
+            )
+            date = datetime.fromtimestamp(decoded_token["exp"])
             data["data"][0]["expirationDate"] = date                           
             systemData = System(**data["data"][0])                             
             systemData.expirationDate = date                                               

--- a/config_flow.py
+++ b/config_flow.py
@@ -28,13 +28,23 @@ from .afore import (
 
 
 async def validate_input(hass: HomeAssistant, *, access_token: str) -> None:
-    """Try using the give system id & api key against the Afore API."""
+    """Try using the given access token against the Afore API."""
     session = async_get_clientsession(hass)
-    afore = Afore(
-        access_token=access_token,
-        session=async_get_clientsession(hass),
+
+    # Create a simple class or named tuple that has a 'data' attribute
+    # This 'data' attribute must be a dictionary containing CONF_ACCESS_TOKEN
+    class DummyConfigEntryForValidation:
+        def __init__(self, token_to_validate: str):
+            self.data = {CONF_ACCESS_TOKEN: token_to_validate}
+
+    dummy_entry = DummyConfigEntryForValidation(access_token)
+
+    afore_client = Afore(
+        hass=hass, # Pass the hass object
+        config_entry=dummy_entry, # Pass the dummy entry
+        session=session
     )
-    await afore.system()
+    await afore_client.system()
 
 
 class AforeFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -117,7 +127,7 @@ class AforeFlowHandler(ConfigFlow, domain=DOMAIN):
             else:
                 self.hass.config_entries.async_update_entry(
                     self.reauth_entry,
-                    data={**self.reauth_entry.data},
+                    data={**self.reauth_entry.data, CONF_ACCESS_TOKEN: user_input[CONF_ACCESS_TOKEN]},
                 )
                 self.hass.async_create_task(
                     self.hass.config_entries.async_reload(self.reauth_entry.entry_id)

--- a/coordinator.py
+++ b/coordinator.py
@@ -23,8 +23,9 @@ class AforeDataUpdateCoordinator(DataUpdateCoordinator[Status]):
         """Initialize the Afore coordinator."""
         self.config_entry = entry
         self.Afore = Afore(
-            access_token=entry.data[CONF_ACCESS_TOKEN],
-            session=async_get_clientsession(hass),
+            hass=hass,
+            config_entry=self.config_entry,
+            session=async_get_clientsession(hass)
         )
 
         super().__init__(hass, LOGGER, name=DOMAIN, update_interval=SCAN_INTERVAL)


### PR DESCRIPTION
This commit addresses issues with updating and using the API token for the Afore cloud service.

Key changes include:

- Modified `afore.py`:
    - The `Afore` class now retrieves the access token from the Home Assistant `ConfigEntry` rather than taking it as a direct constructor argument.
    - It requires `hass` and `config_entry` objects in its constructor to facilitate this.

- Updated `coordinator.py`:
    - The `AforeDataUpdateCoordinator` now instantiates the `Afore` class by passing the `hass` and `config_entry` objects.

- Improved `config_flow.py`:
    - The re-authentication flow (`async_step_reauth_confirm`) now correctly saves the new access token to the `ConfigEntry`.
    - The `validate_input` function has been adapted to work with the modified `Afore` class constructor by using a dummy `ConfigEntry` object for validation purposes. This ensures token validation works during initial setup and re-auth.
    - The options flow for updating the token via "Configure" now correctly uses the new token, and relies on Home Assistant's standard mechanism to reload the integration.

These changes allow you to initially set the token and subsequently update it via the integration's configuration options in Home Assistant without requiring a manual reload of HA itself. The integration should pick up the new token automatically after it's updated in the configuration.